### PR TITLE
- Remove cocoapods in component-tree module. Use xcframework directly instead

### DIFF
--- a/uistate3/iosApp/Podfile
+++ b/uistate3/iosApp/Podfile
@@ -1,5 +1,0 @@
-target 'UiState3Demo' do
-  use_frameworks!
-  platform :ios, '14.1'
-  pod 'uistate3', :path => '../shared'
-end

--- a/uistate3/iosApp/UiState3Demo.xcodeproj/project.pbxproj
+++ b/uistate3/iosApp/UiState3Demo.xcodeproj/project.pbxproj
@@ -8,14 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		2152FB042600AC8F00CF470E /* iosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iosApp.swift */; };
-		59286A0AA6B600B9AE7F93F6 /* Pods_UiState3Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C1CFD74E97974C1222CFA97 /* Pods_UiState3Demo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0667C47DE0A8746C2FAB0BFF /* Pods-UiState3Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UiState3Demo.debug.xcconfig"; path = "Target Support Files/Pods-UiState3Demo/Pods-UiState3Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		1C1CFD74E97974C1222CFA97 /* Pods_UiState3Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UiState3Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2152FB032600AC8F00CF470E /* iosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosApp.swift; sourceTree = "<group>"; };
-		6380C3F275510D5208FDF1CB /* Pods-UiState3Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UiState3Demo.release.xcconfig"; path = "Target Support Files/Pods-UiState3Demo/Pods-UiState3Demo.release.xcconfig"; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9416FB712977C22A00B53976 /* UiState3Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UiState3Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB3632DC29227652001CCB65 /* TeamId.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TeamId.xcconfig; sourceTree = "<group>"; };
@@ -26,27 +22,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59286A0AA6B600B9AE7F93F6 /* Pods_UiState3Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3EC89B47F3ABC233A430ADE1 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				0667C47DE0A8746C2FAB0BFF /* Pods-UiState3Demo.debug.xcconfig */,
-				6380C3F275510D5208FDF1CB /* Pods-UiState3Demo.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		74043C056F8CBC5A10F453CB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1C1CFD74E97974C1222CFA97 /* Pods_UiState3Demo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -57,7 +41,6 @@
 				AB1DB47929225F7C00F7AF9C /* Configuration */,
 				7555FF7D242A565900829871 /* iosApp */,
 				9416FB712977C22A00B53976 /* UiState3Demo.app */,
-				3EC89B47F3ABC233A430ADE1 /* Pods */,
 				74043C056F8CBC5A10F453CB /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -86,7 +69,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "UiState3Demo" */;
 			buildPhases = (
-				E8D673591E7196AEA2EA10E2 /* [CP] Check Pods Manifest.lock */,
+				942802AE299F61BA00D56B64 /* ShellScript */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF79242A565900829871 /* Resources */,
 				9964867F0862B4D9FB6ABFC7 /* Frameworks */,
@@ -144,7 +127,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		E8D673591E7196AEA2EA10E2 /* [CP] Check Pods Manifest.lock */ = {
+		942802AE299F61BA00D56B64 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -152,19 +135,14 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-UiState3Demo-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :uistate3:embedAndSignAppleFrameworkForXcode\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -300,7 +278,6 @@
 		};
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0667C47DE0A8746C2FAB0BFF /* Pods-UiState3Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -308,11 +285,17 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				INFOPLIST_FILE = iosApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					shared,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pablichj.incubator.uistate3--TEAM-ID-";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.pablichj.incubator.uistate3;
@@ -325,7 +308,6 @@
 		};
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6380C3F275510D5208FDF1CB /* Pods-UiState3Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -333,11 +315,17 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				INFOPLIST_FILE = iosApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					shared,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pablichj.incubator.uistate3--TEAM-ID-";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.pablichj.incubator.uistate3;

--- a/uistate3/iosApp/iosApp/iosApp.swift
+++ b/uistate3/iosApp/iosApp/iosApp.swift
@@ -1,5 +1,5 @@
 import UIKit
-import uistate3
+import shared
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/uistate3/shared/build.gradle.kts
+++ b/uistate3/shared/build.gradle.kts
@@ -1,10 +1,5 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
-
-//import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
-
 plugins {
     kotlin("multiplatform")
-    //kotlin("native.cocoapods")
     id("com.android.library")
     id("org.jetbrains.compose")
     id("maven-publish")
@@ -75,10 +70,9 @@ kotlin {
     }
 
     // IOS
-    //ios()
+    //iosX64()
+    //iosArm64()
     //iosSimulatorArm64()
-    iosArm64()
-    iosSimulatorArm64()
 
     // Do not include the cocoapod plugin here, it forces all composables to be internal for iOS
     // target to compile.
@@ -94,24 +88,24 @@ kotlin {
 //        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
 //    }
 
-    //Uncomment if not using cocoapods, and want to use xcframeworks directly
-    /*val xcf = XCFramework()
+    //Comment it out if using cocoapods, and don't want to use xcframeworks directly
     listOf(
+        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {
         it.binaries.framework {
             baseName = "shared"
-            xcf.add(this)
         }
-    }*/
+    }
 
     // JS
     js(IR) {
         browser()
     }
 
-    // WASM, once on kotlin 1.8.20
+    // WASM, once kotlin 1.8.20 is out. Although I believe this should go in the jsApp module not
+    // in the library. Perhaps can go here without the binaries.executable() statement
     /*wasm {
         binaries.executable()
         browser {}
@@ -119,22 +113,6 @@ kotlin {
 
     // JVM
     jvm("desktop")
-
-    // MACOS
-    /*macosX64 {
-        binaries {
-            executable {
-                entryPoint = "main"
-            }
-        }
-    }
-    macosArm64 {
-        binaries {
-            executable {
-                entryPoint = "main"
-            }
-        }
-    }*/
 
     sourceSets {
         // COMMON
@@ -170,26 +148,21 @@ kotlin {
         val androidInstrumentedTest by getting
 
         // IOS
-        /*val iosMain by getting
-        val iosTest by getting
-        val iosSimulatorArm64Main by getting {
-            dependsOn(iosMain)
-        }
-        val iosSimulatorArm64Test by getting {
-            dependsOn(iosTest)
-        }*/
-
+        val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting
         val iosMain by creating {
             dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
             iosSimulatorArm64Main.dependsOn(this)
         }
+        val iosX64Test by getting
         val iosArm64Test by getting
         val iosSimulatorArm64Test by getting
         val iosTest by creating {
             dependsOn(commonTest)
+            iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
             iosSimulatorArm64Test.dependsOn(this)
         }
@@ -201,19 +174,9 @@ kotlin {
         /*val wasmMain by getting
         val wasmTest by getting
         */
+
         // JVM
         val desktopMain by getting
-
-        // MACOS
-        /*val macosMain by creating {
-            dependsOn(commonMain)
-        }
-        val macosX64Main by getting {
-            dependsOn(macosMain)
-        }
-        val macosArm64Main by getting {
-            dependsOn(macosMain)
-        }*/
     }
 
     /*kotlinArtifacts {

--- a/uistate3/shared/src/commonMain/kotlin/com/pablichj/incubator/uistate3/node/adaptable/IWindowSizeInfoProvider.kt
+++ b/uistate3/shared/src/commonMain/kotlin/com/pablichj/incubator/uistate3/node/adaptable/IWindowSizeInfoProvider.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.State
 
 abstract class IWindowSizeInfoProvider {
     @Composable
-    abstract fun windowSizeInfo(): State<WindowSizeInfo>
+    internal abstract fun windowSizeInfo(): State<WindowSizeInfo>
 }
 
 sealed interface WindowSizeInfo {

--- a/uistate3/shared/src/macosMain/kotlin/currentTime.macos.kt
+++ b/uistate3/shared/src/macosMain/kotlin/currentTime.macos.kt
@@ -1,8 +1,0 @@
-package com.pablichj.incubator.uistate3
-
-import platform.Foundation.NSDate
-import platform.Foundation.timeIntervalSince1970
-
-actual fun timestampMs(): Long {
-    return NSDate().timeIntervalSince1970().toLong()
-}


### PR DESCRIPTION
- Remove cocoapods in component-tree module. Use xcframework directly instead
- Remove remnants of the macos native target.